### PR TITLE
Check with moduleTemplates before resolving a loader

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -11,7 +11,7 @@ NpmInstallPlugin.prototype.apply = function(compiler) {
   compiler.plugin("normal-module-factory", this.listenToFactory);
 
   // Install loaders on demand
-  compiler.resolvers.loader.plugin("module", this.resolveLoader.bind(this));
+  compiler.resolvers.loader.plugin("module", this.resolveLoader.bind(this, compiler.options.resolveLoader.moduleTemplates));
 
   // Install project dependencies on demand
   compiler.resolvers.normal.plugin("module", this.resolveModule.bind(this));
@@ -45,7 +45,16 @@ NpmInstallPlugin.prototype.resolveModule = function(result, next) {
   next();
 };
 
-NpmInstallPlugin.prototype.resolveLoader = function(result, next) {
+NpmInstallPlugin.prototype.resolveLoader = function(moduleTemplates, result, next) {
+  for(var i=0; i < moduleTemplates.length; i++) {
+    var dep = installer.check(moduleTemplates[i].replace("*",result.request));
+    console.log(dep);
+    if (!dep) {
+      next();
+      return;
+    }
+  }
+
   this.resolve(result);
 
   next();

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -26,6 +26,11 @@ describe("plugin", function() {
           loader: { plugin: expect.createSpy() },
           normal: { plugin: expect.createSpy() },
         },
+        options: {
+          resolveLoader: {
+            moduleTemplates: []
+          }
+        }
       };
 
       this.plugin.apply(this.compiler);
@@ -47,7 +52,7 @@ describe("plugin", function() {
       expect(this.compiler.resolvers.loader.plugin.calls.length).toBe(1);
       expect(this.compiler.resolvers.loader.plugin.calls[0].arguments).toEqual([
         "module",
-        this.plugin.resolveLoader.bind(this.plugin)
+        this.plugin.resolveLoader.bind(this.plugin, this.compiler.options.resolveLoader.moduleTemplates)
       ]);
     });
 
@@ -187,19 +192,30 @@ describe("plugin", function() {
 
   describe(".resolveLoader", function() {
     beforeEach(function() {
+      this.check = expect.spyOn(installer, "check");
       this.resolve = expect.spyOn(this.plugin, "resolve");
       this.next = expect.createSpy();
     });
 
     afterEach(function() {
       this.resolve.restore();
+      this.check.restore();
       this.next.restore();
     });
 
-    it("should call .resolve", function() {
+    it("should not call .resolve when found in moduleTemplates", function() {
+      var result = { path: "node_modules", request: "foo" };
+      this.check.andReturn();
+      this.plugin.resolveLoader(["*"], result, this.next);
+
+      expect(this.check.calls.length).toBe(1);
+      expect(this.resolve.calls.length).toBe(0);
+    });
+
+    it("should call .resolve if module not found in moduleTemplates", function() {
       var result = { path: "node_modules", request: "foo" };
 
-      this.plugin.resolveLoader(result, this.next);
+      this.plugin.resolveLoader([], result, this.next);
 
       expect(this.resolve.calls.length).toBe(1);
       expect(this.resolve.calls[0].arguments).toEqual([result]);


### PR DESCRIPTION
This prevents from loading modules such as babel and style when using shorthand syntax in webpack config and closes issue #16 

I'm not entirely sure about the tests. Honestly I didn't understand all the reasoning behind check but this did the trick.