### PR TITLE
Mismatch between code and documentation

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -30,7 +30,7 @@ NpmInstallPlugin.prototype.resolve = function(result) {
   var dep = installer.check(result.request);
 
   if (dep) {
-    installer.install(dep, this.options.cli);
+    installer.install(dep, this.options);
   }
 
   return dep;

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -5,10 +5,8 @@ var Plugin = require("../src/plugin");
 describe("plugin", function() {
   beforeEach(function() {
     this.options = {
-      cli: {
-        save: true,
-        saveDev: false,
-      },
+      save: true,
+      saveDev: false,
     };
 
     this.plugin = new Plugin(this.options);
@@ -147,7 +145,7 @@ describe("plugin", function() {
       expect(this.install.calls.length).toBe(1);
       expect(this.install.calls[0].arguments).toEqual([
         this.result.request,
-        this.options.cli
+        this.options
       ]);
     });
   });


### PR DESCRIPTION
In the README.md there is an example on how to configure this plugin. 

```
plugins: [
  new NpmInstallPlugin({
    ...
    cacheMin: 999999  // --cache-min=999999 (prefer NPM cached version)
    registry: "..."   // --registry="..."
    save: true,       // --save
    saveDev: true,    // --save-dev
    saveExact: true,  // --save-exact
    ...
  }),
]
```
However in the code these options are assumed to be located on a `cli` property. https://github.com/ericclemmons/npm-install-webpack-plugin/blob/master/src/plugin.js#L33

I assume one is outdated and should be updated. I can create a PR for this but I would first need to know where the change should be done.