### PR TITLE
Support loader shorthand (e.g. "babel" vs. "babel-loader")

### DIFF
--- a/example/webpack.config.babel.js
+++ b/example/webpack.config.babel.js
@@ -8,15 +8,15 @@ export const defaults = {
 
   module: {
     loaders: [
-      { test: /\.css$/, loader: "style-loader" },
-      { test: /\.css$/, loader: "css-loader", query: { localIdentName: "[name]-[local]--[hash:base64:5]" } },
-      { test: /\.eot$/, loader: "file-loader" },
-      { test: /\.js$/, loader: "babel-loader", query: { cacheDirectory: true }, exclude: /node_modules/ },
-      { test: /\.json$/, loader: "json-loader" },
-      { test: /\.(png|jpg)$/, loader: "url-loader", query: { limit: 8192 } }, // Inline base64 URLs for <= 8K images
-      { test: /\.svg$/, loader: "url-loader", query: { mimetype: "image/svg+xml" } },
-      { test: /\.ttf$/, loader: "url-loader", query: { mimetype: "application/octet-stream" } },
-      { test: /\.(woff|woff2)$/, loader: "url-loader", query: { mimetype: "application/font-woff" } },
+      { test: /\.css$/, loader: "style" },
+      { test: /\.css$/, loader: "css", query: { localIdentName: "[name]-[local]--[hash:base64:5]" } },
+      { test: /\.eot$/, loader: "file" },
+      { test: /\.js$/, loader: "babel", query: { cacheDirectory: true }, exclude: /node_modules/ },
+      { test: /\.json$/, loader: "json" },
+      { test: /\.(png|jpg)$/, loader: "url", query: { limit: 8192 } }, // Inline base64 URLs for <= 8K images
+      { test: /\.svg$/, loader: "url", query: { mimetype: "image/svg+xml" } },
+      { test: /\.ttf$/, loader: "url", query: { mimetype: "application/octet-stream" } },
+      { test: /\.(woff|woff2)$/, loader: "url", query: { mimetype: "application/font-woff" } },
     ],
   },
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -48,6 +48,11 @@ NpmInstallPlugin.prototype.resolveModule = function(result, next) {
 NpmInstallPlugin.prototype.resolveLoader = function(result, next) {
   var loader = result.request;
 
+  // Ensure loaders end with `-loader` (e.g. `babel` => `babel-loader`)
+  if (!loader.match(/\-loader$/)) {
+    loader += "-loader";
+  }
+
   this.resolve(loader);
 
   next();

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -26,8 +26,8 @@ NpmInstallPlugin.prototype.listenToFactory = function(factory) {
   });
 };
 
-NpmInstallPlugin.prototype.resolve = function(result) {
-  var dep = installer.check(result.request);
+NpmInstallPlugin.prototype.resolve = function(request) {
+  var dep = installer.check(request);
 
   if (dep) {
     installer.install(dep, this.options);
@@ -39,14 +39,16 @@ NpmInstallPlugin.prototype.resolve = function(result) {
 NpmInstallPlugin.prototype.resolveModule = function(result, next) {
   // Only install direct dependencies, not sub-dependencies
   if (!result.path.match("node_modules")) {
-    this.resolve(result);
+    this.resolve(result.request);
   }
 
   next();
 };
 
 NpmInstallPlugin.prototype.resolveLoader = function(result, next) {
-  this.resolve(result);
+  var loader = result.request;
+
+  this.resolve(loader);
 
   next();
 };

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -115,7 +115,7 @@ describe("plugin", function() {
     });
 
     it("should check if request is installed", function() {
-      this.plugin.resolve(this.result);
+      this.plugin.resolve(this.result.request);
 
       expect(this.check.calls.length).toBe(1);
       expect(this.check.calls[0].arguments).toEqual([this.result.request]);
@@ -124,7 +124,7 @@ describe("plugin", function() {
     it("should return the value of the check", function() {
       this.check.andReturn(this.result.request);
 
-      var result = this.plugin.resolve(this.result);
+      var result = this.plugin.resolve(this.result.request);
 
       expect(this.check.calls.length).toBe(1);
       expect(this.check.calls[0].arguments).toEqual([this.result.request]);
@@ -167,7 +167,7 @@ describe("plugin", function() {
       this.plugin.resolveModule(result, this.next);
 
       expect(this.resolve.calls.length).toBe(1);
-      expect(this.resolve.calls[0].arguments).toEqual([result]);
+      expect(this.resolve.calls[0].arguments).toEqual(["foo"]);
       expect(this.next.calls.length).toBe(1);
       expect(this.next.calls[0].arguments).toEqual([]);
     });
@@ -195,12 +195,21 @@ describe("plugin", function() {
     });
 
     it("should call .resolve", function() {
-      var result = { path: "node_modules", request: "foo" };
+      var result = { path: "node_modules", request: "babel-loader" };
 
       this.plugin.resolveLoader(result, this.next);
 
       expect(this.resolve.calls.length).toBe(1);
-      expect(this.resolve.calls[0].arguments).toEqual([result]);
+      expect(this.resolve.calls[0].arguments).toEqual(["babel-loader"]);
+    });
+
+    it("should ensure loaders end with `-loader`", function() {
+      var result = { path: "node_modules", request: "babel" };
+
+      this.plugin.resolveLoader(result, this.next);
+
+      expect(this.resolve.calls.length).toBe(1);
+      expect(this.resolve.calls[0].arguments).toEqual(["babel-loader"]);
     });
   });
 });


### PR DESCRIPTION
This plugin is awesome. My pain is all in the "Why" section in the readme :+1:
But why do I get `installing babel` when I use the plugin for the first time?

- the module babel itself seems to be deprecated, in favor of babel-cli & babel-core
- except babel-polyfill, babel-loader, etc, I didn't import babel in my code at all

Thanks!