### PR TITLE
Support installation of packages with a period in their name, e.g. lodash.random

### DIFF
--- a/example/lib/App/index.js
+++ b/example/lib/App/index.js
@@ -1,3 +1,4 @@
+import capitalize from "lodash.capitalize";
 import React from "react";
 
 import "./App.css";
@@ -16,7 +17,7 @@ export default class App extends React.Component {
 
         <div className="jumbotron">
           <h1>
-            It Works!
+            {capitalize("it works!")}
           </h1>
 
           <p>

--- a/src/installer.js
+++ b/src/installer.js
@@ -5,7 +5,7 @@ var path = require("path");
 var util = require("util");
 
 var INTERNAL = /^\./; // Match "./client", "../something", etc.
-var EXTERNAL = /^[a-z\-0-9]+$/; // Match "react", "path", "fs", etc.
+var EXTERNAL = /^[a-z\-0-9\.]+$/; // Match "react", "path", "fs", "lodash.random", etc.
 
 module.exports.check = function(request) {
   if (!request) {


### PR DESCRIPTION
Re-reporting from insin/nwb#77, which would have been using v2, but I just checked this doesn't work in v3 in the development branch.

The external module check doesn't allow for package names which contain a period: https://github.com/ericclemmons/npm-install-webpack-plugin/blob/ea64307766ee31c0f4b314ad27d0c717471373a1/src/installer.js#L8