### PR TITLE
Initialize missing `package.json`

### DIFF
--- a/src/installer.js
+++ b/src/installer.js
@@ -115,6 +115,19 @@ module.exports.checkBabel = function checkBabel() {
   }.bind(this));
 };
 
+module.exports.checkPackage = function checkPackage() {
+  try {
+    require.resolve(path.join(process.cwd(), "package.json"));
+
+    return;
+  } catch (e) {
+    // package.json does not exist
+  }
+
+  console.info("Initializing `%s`...", "package.json");
+  spawn.sync("npm", ["init -y"], { stdio: "inherit" });
+};
+
 module.exports.install = function install(dep, options) {
   if (!dep) {
     return;

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -31,6 +31,7 @@ function NpmInstallPlugin(options) {
   this.options = options || {};
   this.resolving = {};
 
+  installer.checkPackage();
   installer.checkBabel();
 }
 


### PR DESCRIPTION
Can be useful when you're quickly testing something, and not actually building an app.