### PR TITLE
Install peerDependencies

### DIFF
--- a/src/installer.js
+++ b/src/installer.js
@@ -128,12 +128,16 @@ module.exports.checkPackage = function checkPackage() {
   spawn.sync("npm", ["init -y"], { stdio: "inherit" });
 };
 
-module.exports.install = function install(dep, options) {
-  if (!dep) {
+module.exports.install = function install(deps, options) {
+  if (!deps) {
     return;
   }
 
-  var args = ["install"].concat([dep]).filter(Boolean);
+  if (!Array.isArray(deps)) {
+    deps = [deps];
+  }
+
+  var args = ["install"].concat(deps).filter(Boolean);
 
   if (options) {
     for (option in options) {
@@ -152,9 +156,14 @@ module.exports.install = function install(dep, options) {
     }
   }
 
-  console.info("Installing `%s`...", dep);
+  deps.forEach(function(dep) {
+    console.info("Installing %s...", dep);
+  });
 
-  var output = spawn.sync("npm", args, { stdio: "inherit" });
+  // Ignore input, capture output, show errors
+  var output = spawn.sync("npm", args, {
+    stdio: ["ignore", "pipe", "inherit"]
+  });
 
   return output;
 };

--- a/src/installer.js
+++ b/src/installer.js
@@ -75,9 +75,6 @@ module.exports.checkBabel = function checkBabel() {
     return;
   }
 
-  // `babel-core` is required for `babel-loader`
-  this.install(this.check("babel-core"));
-
   // Default plugins/presets
   var options = Object.assign({
     plugins: [],
@@ -98,10 +95,10 @@ module.exports.checkBabel = function checkBabel() {
     presets: [],
   }, options.env.development);
 
-  // Accumulate all dependencies
-  var deps = options.plugins.map(function(plugin) {
+  // Accumulate babel-core (required for babel-loader)+ all dependencies
+  var deps = ["babel-core"].concat(options.plugins.map(function(plugin) {
     return "babel-plugin-" + plugin;
-  }).concat(options.presets.map(function(preset) {
+  })).concat(options.presets.map(function(preset) {
     return "babel-preset-" + preset;
   })).concat(options.env.development.plugins.map(function(plugin) {
     return "babel-plugin-" + plugin;
@@ -110,9 +107,7 @@ module.exports.checkBabel = function checkBabel() {
   }));
 
   // Check for & install dependencies
-  deps.forEach(function(dep) {
-    this.install(this.check(dep));
-  }.bind(this));
+  this.install(deps.filter(this.check.bind(this)));
 };
 
 module.exports.checkPackage = function checkPackage() {


### PR DESCRIPTION
When using this webpack plugin in a project using `@cycle/core` which has `rx` as peer dependency I met an infinite loop:

```bash
node_modules/.bin/webpack
ts-loader: Using typescript@1.8.10 and /Users/chadrien/src/ml/tsconfig.json
Installing `@cycle/core`...
/Users/chadrien/src/ml
├── @cycle/core@6.0.3  extraneous
└── UNMET PEER DEPENDENCY rx@*

npm WARN @cycle/core@6.0.3 requires a peer of rx@* but none was installed.
npm WARN ml No description
npm WARN ml No repository field.
npm WARN ml No license field.
Installing `@cycle/core`...
/Users/chadrien/src/ml
├── @cycle/core@6.0.3  extraneous
└── UNMET PEER DEPENDENCY rx@*

npm WARN @cycle/core@6.0.3 requires a peer of rx@* but none was installed.
npm WARN ml No description
npm WARN ml No repository field.
npm WARN ml No license field.
Installing `@cycle/core`...
/Users/chadrien/src/ml
├── @cycle/core@6.0.3  extraneous
└── UNMET PEER DEPENDENCY rx@*
```

And going on until a hit ctrl-c

Maybe an approach to this would be to install the peer dependencies of a package if it has any.