### PR TITLE
Performance

### DIFF
--- a/src/installer.js
+++ b/src/installer.js
@@ -138,6 +138,10 @@ module.exports.install = function install(deps, options) {
     deps = [deps];
   }
 
+  if (!deps.length) {
+    return;
+  }
+
   var args = ["install"].concat(deps).filter(Boolean);
 
   if (options) {

--- a/test/installer.test.js
+++ b/test/installer.test.js
@@ -253,6 +253,12 @@ describe("installer", function() {
       });
     });
 
+    context("given an empty array", function() {
+      it("should return undefined", function () {
+        expect(installer.install([])).toEqual(undefined);
+      });
+    });
+
     context("given a dependency", function() {
       it("should install it", function() {
         var result = installer.install("foo");

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -66,7 +66,7 @@ describe("plugin", function() {
       expect(this.compiler.plugin.calls.length).toBe(1);
       expect(this.compiler.plugin.calls[0].arguments).toEqual([
         "watch-run",
-        this.plugin.preInstall.bind(this.plugin)
+        this.plugin.preCompile.bind(this.plugin)
       ]);
     });
 
@@ -87,7 +87,7 @@ describe("plugin", function() {
     });
   });
 
-  describe(".preInstall", function() {
+  describe(".preCompile", function() {
     beforeEach(function() {
       this.run = expect.spyOn(webpack.Compiler.prototype, "run").andCall(function(callback) {
         callback();
@@ -101,7 +101,7 @@ describe("plugin", function() {
     it("should perform dryrun", function(done) {
       var compilation = {};
 
-      this.plugin.preInstall(compilation, function() {
+      this.plugin.preCompile(compilation, function() {
         expect(this.run).toHaveBeenCalled();
         done();
       }.bind(this));


### PR DESCRIPTION
Hi,

I'm getting reports about reduced performance. Here's the [thread](http://survivejs.com/webpack_react/webpack_and_react/#comment-2664052295).

Quote:

> I was experiencing slow bundle times as well. Running on OSX 10.10.5.
> After playing around with it for a bit, I noticed that removing the NpmInstallPlugin decreased my bundle time from about 6 seconds to less than a second, when making changes to the app.

Relevant setup can be found [here](https://github.com/survivejs/webpack_react/tree/0c19e26f037a78e21afee3db8f07b1de65cdec7c/project_source/02_developing_with_webpack/kanban_app).

Let me know if you need more information.