### PR TITLE
Warn on missing NPM packages

### DIFF
--- a/src/installer.js
+++ b/src/installer.js
@@ -179,7 +179,6 @@ module.exports.install = function install(deps, options) {
 
   if (output.status) {
     deps.forEach(function(dep) {
-      console.warn("Ignoring %s due to errors installing...", dep);
       erroneous.push(dep);
     });
   }

--- a/src/installer.js
+++ b/src/installer.js
@@ -178,7 +178,10 @@ module.exports.install = function install(deps, options) {
   });
 
   if (output.status) {
-    deps.forEach(erroneous.push.bind(erroneous));
+    deps.forEach(function(dep) {
+      console.warn("Ignoring %s due to errors installing...", dep);
+      erroneous.push(dep);
+    });
   }
 
   var matches = null;

--- a/src/installer.js
+++ b/src/installer.js
@@ -109,13 +109,13 @@ module.exports.checkBabel = function checkBabel() {
     return "babel-preset-" + preset;
   }));
 
-  // Check for erroneous dependencies
-  var erroneous = deps.filter(function(dep) {
+  // Check for missing dependencies
+  var missing = deps.filter(function(dep) {
     return this.check(dep);
   }.bind(this));
 
-  // Install erroneous dependencies
-  this.install(erroneous);
+  // Install missing dependencies
+  this.install(missing);
 };
 
 module.exports.checkPackage = function checkPackage() {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -76,7 +76,19 @@ NpmInstallPlugin.prototype.preCompile = function(compilation, next) {
     this.preCompiler.outputFileSystem = new MemoryFS();
   }
 
-  this.preCompiler.run(next);
+  this.preCompiler.run(function(err, stats) {
+    if (err) {
+      return next(err);
+    }
+
+    var preError = stats.compilation.errors[0];
+
+    if (preError) {
+      return next(preError);
+    }
+
+    next(err, stats);
+  });
 };
 
 NpmInstallPlugin.prototype.resolveExternal = function(context, request, callback) {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -76,19 +76,7 @@ NpmInstallPlugin.prototype.preCompile = function(compilation, next) {
     this.preCompiler.outputFileSystem = new MemoryFS();
   }
 
-  this.preCompiler.run(function(err, stats) {
-    if (err) {
-      return next(err);
-    }
-
-    var preError = stats.compilation.errors[0];
-
-    if (preError) {
-      return next(preError);
-    }
-
-    next(err, stats);
-  });
+  this.preCompiler.run(next);
 };
 
 NpmInstallPlugin.prototype.resolveExternal = function(context, request, callback) {

--- a/test/installer.test.js
+++ b/test/installer.test.js
@@ -106,6 +106,7 @@ describe("installer", function() {
         expect(installer.check("!!./css-loader/index.js',")).toBe(undefined);
       });
     })
+
   });
 
   describe(".checkBabel", function() {
@@ -237,6 +238,7 @@ describe("installer", function() {
       this.sync = expect.spyOn(spawn, "sync").andReturn({ stdout: null });
 
       expect.spyOn(console, "info");
+      expect.spyOn(console, "warn");
     });
 
     afterEach(function() {
@@ -256,6 +258,24 @@ describe("installer", function() {
     context("given an empty array", function() {
       it("should return undefined", function () {
         expect(installer.install([])).toEqual(undefined);
+      });
+    });
+
+    context("given a non-existant module", function() {
+      beforeEach(function() {
+        this.sync.andReturn({ status: 1 });
+      });
+
+      it("should attempt to install once", function() {
+        installer.install("does.not.exist.jsx")
+
+        expect(this.sync).toHaveBeenCalled();
+      });
+
+      it("should not attempt to install it again", function() {
+        installer.install("does.not.exist.jsx")
+
+        expect(this.sync).toNotHaveBeenCalled();
       });
     });
 


### PR DESCRIPTION
I noticed that if you try to import a npm package that doesn't even exist (say you do `import Notes from 'Notes.jsx';`), npm-install-webpack-plugin will still kick in. It might be preferable to handle this some other way (skip install, warn somehow?).