### PR TITLE
New Options (dev, peerDependencies)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,33 +54,39 @@ In your `webpack.config.js`:
 
 ```js
 plugins: [
-  new NpmInstallPlugin(),
+  new NpmInstallPlugin();
 ],
 ```
 
-**If you have an `.npmrc` file in your project,
-those arguments will be used:**
-
-```
-save=true
-save-exact=true
-```
-
-Alternatively, you can provide your own arguments to `npm install`:
+**This is equivalent to**:
 
 ```js
 plugins: [
   new NpmInstallPlugin({
-    ...
-    cacheMin: 999999  // --cache-min=999999 (prefer NPM cached version)
-    registry: "..."   // --registry="..."
-    save: true,       // --save
-    saveDev: true,    // --save-dev
-    saveExact: true,  // --save-exact
-    ...
+    // Use --save or --save-dev
+    dev: false,
+    // Install missing peerDependencies
+    peerDependencies: true,
+  });
+],
+```
+
+You can provide a `Function` to the `dev` to make it dynamic:
+
+```js
+plugins: [
+  new NpmInstallPlugin({
+    dev: function(module, path) {
+      return [
+        "babel-preset-react-hmre",
+        "webpack-dev-middleware",
+        "webpack-hot-middleware",
+      ].indexOf(module) !== -1;
+    },
   }),
 ],
 ```
+
 
 ### License
 

--- a/example/webpack1-dev-server/webpack.config.defaults.js
+++ b/example/webpack1-dev-server/webpack.config.defaults.js
@@ -27,7 +27,15 @@ module.exports = {
   },
 
   plugins: [
-    new NpmInstallPlugin(),
+    new NpmInstallPlugin({
+      dev: function(module, path) {
+        return [
+          "babel-preset-react-hmre",
+          "webpack-dev-middleware",
+          "webpack-hot-middleware",
+        ].indexOf(module) !== -1;
+      },
+    }),
   ],
 
   resolve: {

--- a/example/webpack1/webpack.config.defaults.js
+++ b/example/webpack1/webpack.config.defaults.js
@@ -27,7 +27,15 @@ module.exports = {
   },
 
   plugins: [
-    new NpmInstallPlugin(),
+    new NpmInstallPlugin({
+      dev: function(module, path) {
+        return [
+          "babel-preset-react-hmre",
+          "webpack-dev-middleware",
+          "webpack-hot-middleware",
+        ].indexOf(module) !== -1;
+      },
+    }),
   ],
 
   resolve: {

--- a/example/webpack2/webpack.config.defaults.js
+++ b/example/webpack2/webpack.config.defaults.js
@@ -27,7 +27,15 @@ module.exports = {
   },
 
   plugins: [
-    new NpmInstallPlugin(),
+    new NpmInstallPlugin({
+      dev: function(module, path) {
+        return [
+          "babel-preset-react-hmre",
+          "webpack-dev-middleware",
+          "webpack-hot-middleware",
+        ].indexOf(module) !== -1;
+      },
+    }),
   ],
 
   resolve: {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -29,7 +29,7 @@ var depFromErr = function(err) {
 function NpmInstallPlugin(options) {
   this.preCompiler = null;
   this.compiler = null;
-  this.options = options || {};
+  this.options = Object.assign(installer.defaultOptions, options);
   this.resolving = {};
 
   installer.checkPackage();
@@ -62,7 +62,13 @@ NpmInstallPlugin.prototype.install = function(result) {
   var dep = installer.check(result.request);
 
   if (dep) {
-    installer.install(dep, this.options);
+    var dev = this.options.dev;
+
+    if (typeof this.options.dev === "function") {
+      dev = !!this.options.dev(result.request, result.path);
+    }
+
+    installer.install(dep, Object.assign({}, this.options, { dev: dev }));
   }
 }
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -54,6 +54,18 @@ NpmInstallPlugin.prototype.apply = function(compiler) {
   compiler.resolvers.normal.plugin("module", this.resolveModule.bind(this));
 };
 
+NpmInstallPlugin.prototype.install = function(result) {
+  if (!result) {
+    return;
+  }
+
+  var dep = installer.check(result.request);
+
+  if (dep) {
+    installer.install(dep, this.options);
+  }
+}
+
 NpmInstallPlugin.prototype.preCompile = function(compilation, next) {
   if (!this.preCompiler) {
     var options = this.compiler.options;
@@ -98,11 +110,7 @@ NpmInstallPlugin.prototype.resolveExternal = function(context, request, callback
 
   this.resolve(result, function(err, filepath) {
     if (err) {
-      var dep = installer.check(depFromErr(err));
-
-      if (dep) {
-        installer.install(dep, this.options);
-      }
+      this.install(Object.assign({}, result, { request: depFromErr(err) }));
     }
 
     callback();
@@ -141,11 +149,7 @@ NpmInstallPlugin.prototype.resolveLoader = function(result, next) {
     loader += "-loader";
   }
 
-  var dep = installer.check(loader);
-
-  if (dep) {
-    installer.install(dep, this.options);
-  }
+  this.install(Object.assign({}, result, { request: loader }));
 
   return next();
 };
@@ -166,11 +170,7 @@ NpmInstallPlugin.prototype.resolveModule = function(result, next) {
     this.resolving[result.request] = false;
 
     if (err) {
-      var dep = installer.check(depFromErr(err));
-
-      if (dep) {
-        installer.install(dep, this.options);
-      }
+      this.install(Object.assign({}, result, { request: depFromErr(err) }));
     }
 
     return next();

--- a/test/installer.test.js
+++ b/test/installer.test.js
@@ -6,6 +6,16 @@ var spawn = require("cross-spawn");
 var installer = require("../src/installer");
 
 describe("installer", function() {
+  describe(".defaultOptions", function() {
+    it("should default dev to false", function() {
+      expect(installer.defaultOptions.dev).toEqual(false);
+    });
+
+    it("should default peerDependencies to true", function() {
+      expect(installer.defaultOptions.peerDependencies).toEqual(true);
+    });
+  })
+
   describe(".check", function() {
     context("given nothing", function() {
       it("should return undefined", function() {

--- a/test/installer.test.js
+++ b/test/installer.test.js
@@ -290,32 +290,27 @@ describe("installer", function() {
     });
 
     context("given a dependency", function() {
-      it("should install it", function() {
-        var result = installer.install("foo");
+      context("with no options", function() {
+        it("should install it with --save", function() {
+          var result = installer.install("foo");
 
-        expect(this.sync).toHaveBeenCalled();
-        expect(this.sync.calls.length).toEqual(1);
-        expect(this.sync.calls[0].arguments[0]).toEqual("npm");
-        expect(this.sync.calls[0].arguments[1]).toEqual(["install", "foo"]);
+          expect(this.sync).toHaveBeenCalled();
+          expect(this.sync.calls.length).toEqual(1);
+          expect(this.sync.calls[0].arguments[0]).toEqual("npm");
+          expect(this.sync.calls[0].arguments[1]).toEqual(["install", "foo", "--save"]);
+        });
       });
 
-      context("given options", function() {
-        it("should pass them to child process", function() {
+      context("with dev set to true", function() {
+        it("should install it with --save-dev", function() {
           var result = installer.install("foo", {
-            save: true,
-            saveExact: false,
-            registry: "https://registry.npmjs.com/",
+            dev: true,
           });
 
           expect(this.sync).toHaveBeenCalled();
           expect(this.sync.calls.length).toEqual(1);
           expect(this.sync.calls[0].arguments[0]).toEqual("npm");
-          expect(this.sync.calls[0].arguments[1]).toEqual([
-            "install",
-            "foo",
-            "--save",
-            "--registry='https://registry.npmjs.com/'",
-          ]);
+          expect(this.sync.calls[0].arguments[1]).toEqual(["install", "foo", "--save-dev"]);
         });
       });
 
@@ -338,14 +333,27 @@ describe("installer", function() {
           });
         });
 
-        it("should install peerDependencies", function() {
-          var result = installer.install("redbox-react");
+        context("given no options", function() {
+          it("should install peerDependencies", function() {
+            var result = installer.install("redbox-react");
 
-          expect(this.sync.calls.length).toEqual(2);
-          expect(this.sync.calls[0].arguments[1]).toEqual(["install", "redbox-react"]);
-          expect(this.sync.calls[1].arguments[1]).toEqual(["install", "react@\">=0.13.2 || ^0.14.0-rc1 || ^15.0.0-rc\""]);
+            expect(this.sync.calls.length).toEqual(2);
+            expect(this.sync.calls[0].arguments[1]).toEqual(["install", "redbox-react", "--save"]);
+            expect(this.sync.calls[1].arguments[1]).toEqual(["install", "react@\">=0.13.2 || ^0.14.0-rc1 || ^15.0.0-rc\"", "--save"]);
+          });
         });
-      })
+
+        context("given peerDependencies set to false", function() {
+          it("should not install peerDependencies", function() {
+            var result = installer.install("redbox-react", {
+              peerDependencies: false,
+            });
+
+            expect(this.sync.calls.length).toEqual(1);
+            expect(this.sync.calls[0].arguments[1]).toEqual(["install", "redbox-react", "--save"]);
+          });
+        });
+      });
     });
   });
 });

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -32,8 +32,8 @@ describe("plugin", function() {
     this.next = expect.createSpy();
 
     this.options = {
-      save: true,
-      saveDev: false,
+      dev: false,
+      peerDependencies: true,
     };
 
     this.plugin = new Plugin(this.options);


### PR DESCRIPTION
Use case: allowing configuration of the `npm install` options used to vary based on the module missing dependencies were detected in.

This is pretty niche, but would be neat DX touch for tooling which can auto-configure it for you.

 e.g. if installation is triggered by a module under `src/`, use `--save`; a module under `test/`, use `--save-dev`

Potential API (which suits a plugin, as it would otherwise need to be top-levelled in webpack config for a loader): pass a RegExp as `save`/`saveDev` config which is tested against the relative path from `process.cwd()` to the module the current install is being triggered from:

```js
cli: {
  save: /^src\//,
  saveDev: /^test\//
}
```

Alternatively, allow `cli` or any of its props to be a Function which would take a `module` arg similar to the `minChunks` option for `CommonsChunkPlugin`. Seems a bit overkilly, but you never know.