### PR TITLE
Not parsing versions correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   "dependencies": {
     "cross-spawn": "^2.1.5",
     "lodash.kebabcase": "^4.0.0",
-    "memory-fs": "^0.3.0"
+    "memory-fs": "^0.3.0",
+    "semver": "^5.1.0"
   },
   "devDependencies": {
     "coveralls": "^2.11.8",

--- a/src/installer.js
+++ b/src/installer.js
@@ -184,6 +184,8 @@ module.exports.install = function install(deps, options) {
 
     if (semver.valid(version.replace("^", "").replace("~", ""))) {
       peers.push(util.format("%s@%s", dep, version));
+    } else {
+      console.warn(util.format("%s@\"dep\" is not valid semver. Please install manually.", dep, version));
     }
   }
 

--- a/src/installer.js
+++ b/src/installer.js
@@ -2,6 +2,7 @@ var spawn = require("cross-spawn");
 var fs = require("fs");
 var kebabCase = require("lodash.kebabcase");
 var path = require("path");
+var semver = require("semver");
 var util = require("util");
 
 var EXTERNAL = /^\w[a-z\-0-9\.]+$/; // Match "react", "path", "fs", "lodash.random", etc.
@@ -181,12 +182,9 @@ module.exports.install = function install(deps, options) {
     var dep = matches[1];
     var version = matches[2];
 
-    // Wrap expressions in quotes
-    if (version.match(" ")) {
-      version = util.format('"%s"', version);
+    if (semver.valid(version.replace("^", "").replace("~", ""))) {
+      peers.push(util.format("%s@%s", dep, version));
     }
-
-    peers.push(util.format("%s@%s", dep, version));
   }
 
   if (options.peerDependencies && peers.length) {

--- a/test/installer.test.js
+++ b/test/installer.test.js
@@ -324,6 +324,7 @@ describe("installer", function() {
                 stdout: new Buffer([
                   "/test",
                   "├── redbox-react@1.2.3",
+                  "├── UNMET PEER DEPENDENCY foo@^1.2.3",
                   "└── UNMET PEER DEPENDENCY react@>=0.13.2 || ^0.14.0-rc1 || ^15.0.0-rc",
                 ].join("\n")),
               };
@@ -339,7 +340,7 @@ describe("installer", function() {
 
             expect(this.sync.calls.length).toEqual(2);
             expect(this.sync.calls[0].arguments[1]).toEqual(["install", "redbox-react", "--save"]);
-            expect(this.sync.calls[1].arguments[1]).toEqual(["install", "react@\">=0.13.2 || ^0.14.0-rc1 || ^15.0.0-rc\"", "--save"]);
+            expect(this.sync.calls[1].arguments[1]).toEqual(["install", "foo@^1.2.3", "--save"]);
           });
         });
 


### PR DESCRIPTION
My package depends on `2.1.0-beta.7` while a dependency defines a `peerDependency` on `1 || ^2.1.0-beta`. So my package actually satisfies the `peerDependency`. This plugin seems to be parsing the version incorrectly and tried to install `webpack@"1 || ^2.1.0-beta"`, which fails, because it's not a valid version.