### PR TITLE
Fix failure to initialise package.json in Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "changelog:generate": "github_changelog_generator --future-release $npm_package_version",
     "coverage": "npm test && nyc report --reporter=text-lcov | coveralls",
     "postversion": "npm run version:amend && git push origin master --tags && npm publish",
-    "test": "NODE_ENV=test nyc mocha",
+    "test": "cross-env NODE_ENV=test nyc mocha",
     "version": "npm run changelog",
     "version:amend": "git commit --amend -m \"Release v${npm_package_version}\""
   },
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "coveralls": "^2.11.8",
+    "cross-env": "^1.0.8",
     "expect": "^1.14.0",
     "mocha": "^2.4.5",
     "nyc": "^6.0.0",

--- a/src/installer.js
+++ b/src/installer.js
@@ -129,7 +129,7 @@ module.exports.checkPackage = function checkPackage() {
   }
 
   console.info("Initializing `%s`...", "package.json");
-  spawn.sync("npm", ["init -y"], { stdio: "inherit" });
+  spawn.sync("npm", ["init", "-y"], { stdio: "inherit" });
 };
 
 module.exports.defaultOptions = defaultOptions;

--- a/test/installer.test.js
+++ b/test/installer.test.js
@@ -236,7 +236,7 @@ describe("installer", function() {
         expect(this.sync.calls.length).toEqual(1);
         expect(this.sync.calls[0].arguments).toEqual([
           "npm",
-          ["init -y"],
+          ["init", "-y"],
           { stdio: "inherit" },
         ]);
       });

--- a/test/installer.test.js
+++ b/test/installer.test.js
@@ -76,7 +76,7 @@ describe("installer", function() {
         expect(installer.check("something-linked")).toBe(undefined);
         expect(this.lstatSync.calls.length).toBe(1);
         expect(this.lstatSync.calls[0].arguments).toEqual([
-          [process.cwd(), "node_modules", "something-linked"].join("/"),
+          path.join(process.cwd(), "node_modules", "something-linked"),
         ]);
       });
     });


### PR DESCRIPTION
npm-install-webpack-plugin v4.0.0 / Node v4.4.5 / npm v2.14.16 / Windows 10 Home 64-bit

Before:
```
C:\Users\Jonny\tmp\serve-react>nwb serve-react app.js --auto-install
nwb: serve-react
Initializing `package.json`...

Usage: npm <command>
```

After:
```
C:\Users\Jonny\tmp\serve-react>nwb serve-react app.js --auto-install
nwb: serve-react
Initializing `package.json`...
Wrote to C:\Users\Jonny\tmp\serve-react\package.json:
```