### PR TITLE
Tries to install `babel-loader-loader`

### DIFF
--- a/src/installer.js
+++ b/src/installer.js
@@ -4,7 +4,6 @@ var path = require("path");
 var util = require("util");
 
 var EXTERNAL = /^\w[a-z\-0-9\.]+$/; // Match "react", "path", "fs", "lodash.random", etc.
-var INTERNAL = /^\./; // Match "./client", "../something", etc.
 var PEERS = /UNMET PEER DEPENDENCY ([a-z\-0-9\.]+)@(.+)/gm;
 
 var defaultOptions = { dev: false, peerDependencies: true };

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -148,12 +148,14 @@ NpmInstallPlugin.prototype.resolve = function(result, callback) {
 }
 
 NpmInstallPlugin.prototype.resolveLoader = function(result, next) {
-  var loader = result.request;
-
   // Ensure loaders end with `-loader` (e.g. `babel` => `babel-loader`)
-  if (!loader.match(/\-loader$/)) {
-    loader += "-loader";
-  }
+  // Also force Webpack2's
+  var loader = result.request
+      .split("-loader")
+      .filter(Boolean)
+      .concat("loader")
+      .join("-")
+  ;
 
   this.install(Object.assign({}, result, { request: loader }));
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,5 +1,4 @@
 var MemoryFS = require("memory-fs");
-var path = require("path");
 var webpack = require("webpack");
 
 var installer = require("./installer");


### PR DESCRIPTION
I'm using `babel-loader` as `babel-loader` in my webpack config instead of just `babel`. The plugin seems to be trying to install `babel-loader-loader`.

Which is probably the same for others, but haven't tested.